### PR TITLE
packaging converse to PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you don't plan to edit the package code, we recommend using this method of ru
 2. Create a Python 3.7 virtual environment using [Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) and activate it.
 3. Run the following command to install the pip package of Converse:
    ```
-   pip install -i https://test.pypi.org/pypi/ --extra-index-url https://pypi.org/simple converse-test-command==0.2.16
+   pip install converse-sfr==0.0.2
    ```
 4. Install `svn` on your computer. On Mac, run:
    ```

--- a/README.md
+++ b/README.md
@@ -119,10 +119,15 @@ You can find more details in our paper: https://arxiv.org/abs/2203.12187
 
 If you're using Converse in your research or applications, please cite using this BibTeX:
 ```
-@article{xie2022converse,
-  title={Converse--A Tree-Based Modular Task-Oriented Dialogue System},
-  author={Xie, Tian and Yang, Xinyi and Lin, Angela S. and Wu, Feihong and Hashimoto, Kazuma and Qu, Jin and Kang, Young Mo and Yin, Wenpeng and Wang, Huan and Yavuz, Semih and Wu, Gang and Jones, Michael and Socher, Richard and Zhou, Yingbo and Liu, Wenhao and Xiong, Caiming},
-  journal={arXiv preprint arXiv:2203.12187},
-  year={2022}
+@misc{https://doi.org/10.48550/arxiv.2203.12187,
+  doi = {10.48550/ARXIV.2203.12187},
+  url = {https://arxiv.org/abs/2203.12187},
+  author = {Xie, Tian and Yang, Xinyi and Lin, Angela S. and Wu, Feihong and Hashimoto, Kazuma and Qu, Jin and Kang, Young Mo and Yin, Wenpeng and Wang, Huan and Yavuz, Semih and Wu, Gang and Jones, Michael and Socher, Richard and Zhou, Yingbo and Liu, Wenhao and Xiong, Caiming},
+  keywords = {Computation and Language (cs.CL), Artificial Intelligence (cs.AI), FOS: Computer and information sciences, FOS: Computer and information sciences},
+  title = {Converse: A Tree-Based Modular Task-Oriented Dialogue System},
+  publisher = {arXiv},
+  year = {2022},
+  copyright = {Creative Commons Attribution 4.0 International}
 }
+
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ If you don't plan to edit the package code, we recommend using this method of ru
    ```
    brew install svn
    ```
+   If you are using Linux, check [https://subversion.apache.org/packages.html](https://subversion.apache.org/packages.html) to install `subversion`.
 5. Run `converse-shell` to test if the package is successfully installed.
 If the command line output contains `"Hello, Converse!"`, then you installed the package successfully.
 6. Run `converse-demo` to interact with pre-built example bots, and follow the instructions in your terminal.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ If you don't plan to edit the package code, we recommend using this method of ru
    brew install svn
    ```
    If you are using Linux, check [https://subversion.apache.org/packages.html](https://subversion.apache.org/packages.html) to install `subversion`.
+   For example, on Ubuntu, run:
+   ```
+   apt-get install subversion
+   apt-get install libapache2-mod-svn
+   ```
 5. Run `converse-shell` to test if the package is successfully installed.
 If the command line output contains `"Hello, Converse!"`, then you installed the package successfully.
 6. Run `converse-demo` to interact with pre-built example bots, and follow the instructions in your terminal.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ flask==1.1.1
 Flask-Cors==3.0.9
 fuzzysearch==0.7.0
 itsdangerous==2.0.1
+Jinja2<3.1.0
 jsonpickle==1.4.2
 nltk==3.6.6
 num2words==0.5.10
@@ -16,4 +17,6 @@ pyyaml==5.4
 redis==3.5.3
 requests==2.23.0
 scikit-learn==0.22.2.post1
+Werkzeug==2.0.3
 wrapt_timeout_decorator==1.3.1
+

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="converse-test-command",
-    version="0.2.16",
+    name="converse-sfr",
+    version="0.0.2",
     author="Salesforce Research",
     author_email="converse.ai@salesforce.com",
     description="A framework that facilitates creating task-oriented chatbot",
@@ -28,6 +28,7 @@ setuptools.setup(
         "Flask-Cors==3.0.9",
         "fuzzysearch==0.7.0",
         "itsdangerous==2.0.1",
+        "Jinja2<3.1.0",
         "jsonpickle==1.4.2",
         "nltk==3.6.6",
         "num2words==0.5.10",
@@ -39,6 +40,7 @@ setuptools.setup(
         "redis==3.5.3",
         "requests==2.23.0",
         "scikit-learn==0.22.2.post1",
+        "Werkzeug==2.0.3",
         "wrapt_timeout_decorator==1.3.1",
     ],
     entry_points={


### PR DESCRIPTION
Packaged converse to PyPI.
Added 2 more required packages(Werkzeug==2.0.3, Jinja2<3.1.0) in `requirements.txt` and `setup.py`.
Now Converse can be installed by `pip install converse-sfr==0.0.2`
